### PR TITLE
Update PlatformThread.cpp

### DIFF
--- a/activemq-cpp/src/main/decaf/internal/util/concurrent/windows/PlatformThread.cpp
+++ b/activemq-cpp/src/main/decaf/internal/util/concurrent/windows/PlatformThread.cpp
@@ -352,15 +352,27 @@ void PlatformThread::createNewThread(decaf_thread_t* handle, threadMainMethod th
                                      int priority, long long stackSize, long long* threadId) {
 
     unsigned int osThreadId = 0;
+    uintptr_t result = _beginthreadex(NULL, (DWORD)0, threadMain, threadArg, 0, &osThreadId);
+    char errorMessage[256];
 
-    *handle = (HANDLE)_beginthreadex(
-         NULL, (DWORD)0, threadMain, threadArg, 0, &osThreadId );
-
-    if (*handle == 0) {
-        throw RuntimeException(
-            __FILE__, __LINE__, "Failed to create new Thread." );
+    *handle = nullptr;
+    
+    if (((uintptr_t )-1L) == result)
+    {
+        sprintf_s(errorMessage, sizeof(errorMessage), "Failed to create new Thread. Result: -1. Error code: %d. DOS Error code: %d.", errno, _doserrno);
+        
+        throw RuntimeException(__FILE__, __LINE__, errorMessage);
     }
-
+    
+    *handle = (decaf_thread_t)result;
+    
+    if (nullptr == *handle)
+    {
+        sprintf_s(errorMessage, sizeof(errorMessage), "Failed to create new Thread.  Result: NULL. Error code: %d. DOS Error code: %d.", errno, _doserrno);
+        
+        throw RuntimeException(__FILE__, __LINE__, errorMessage);
+    }
+    
     *threadId = (long long)osThreadId;
 }
 


### PR DESCRIPTION
Added handling thread creation failure when  _beginthreadex() returns (uintptr_t )-1L. See MSDN:
https://msdn.microsoft.com/en-us/library/kdzttdcb.aspx
for details.
Added errno and _doserrno to exception message.
Reason:
PlatformThread::createNewThread() is a public method. Developer who uses this method expects, that it is enough to catch an exception and next apply usual null pointer checking. Value -1L is different than NULL so it would cause memory access violation on de-reference.